### PR TITLE
Remove the setting of the margin so that the consumer can decide

### DIFF
--- a/src/vue-faq-accordion.vue
+++ b/src/vue-faq-accordion.vue
@@ -187,7 +187,6 @@
 
     &-wrapper {
       max-width: 825px;
-      margin: 0 auto;
     }
 
     &__title {


### PR DESCRIPTION
At the moment it isn't possible to left align the component without having to know the internals of the component and overriding the faq-wrapper.  The only option is to have it centered.  If the margin is removed from this component then the consumer can just set their own layout.

e.g.

```
<vue-faq-accordion class="my-accordion"></vue-faq-accordion>

.my-accordion {
  margin-left: 20px;
}
```